### PR TITLE
Add initial support for PositionedImages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,1 @@
+* Add initial support for PositionedImages

--- a/src/doc-service/index.js
+++ b/src/doc-service/index.js
@@ -16,7 +16,7 @@ const range = ( n ) => {
 export function DocService( DocumentApp, imageLinker ) {
 	const childrenOf = ( element ) => range( element.getNumChildren() ).map( i => element.getChild( i ) )
 
-	const renderContainer = ( element ) => childrenOf( element ).map( renderElement ).join( '' )
+	const renderContainer = ( element ) => childrenOf( element ).map( renderElement ).concat( renderPositionedImages( element ) ).join( '' )
 
 	const renderParagraph = Paragraph( DocumentApp, renderContainer );
 	const renderTable = Table( renderContainer );
@@ -38,6 +38,10 @@ export function DocService( DocumentApp, imageLinker ) {
 			default:
 				return element.getType() + ': ' + element.toString()
 		}
+	}
+
+	function renderPositionedImages( container ) {
+		return container.getPositionedImages().map( renderInlineImage )
 	}
 
 	return renderContainer

--- a/src/doc-service/index.js
+++ b/src/doc-service/index.js
@@ -20,7 +20,7 @@ export function DocService( DocumentApp, imageLinker ) {
 
 	const renderParagraph = Paragraph( DocumentApp, renderContainer );
 	const renderTable = Table( renderContainer );
-	const renderInlineImage = InlineImage( imageLinker );
+	const renderImage = InlineImage( imageLinker );
 	const renderListItem = ListItem( DocumentApp, renderContainer );
 
 	function renderElement( element ) {
@@ -30,7 +30,7 @@ export function DocService( DocumentApp, imageLinker ) {
 			case DocumentApp.ElementType.TEXT:
 				return renderText( element )
 			case DocumentApp.ElementType.INLINE_IMAGE:
-				return renderInlineImage( element )
+				return renderImage( element )
 			case DocumentApp.ElementType.LIST_ITEM:
 				return renderListItem( element )
 			case DocumentApp.ElementType.TABLE:
@@ -41,7 +41,11 @@ export function DocService( DocumentApp, imageLinker ) {
 	}
 
 	function renderPositionedImages( container ) {
-		return container.getPositionedImages().map( renderInlineImage )
+		if ( ! container.getPositionedImages ) {
+			return [];
+		}
+
+		return container.getPositionedImages().map( renderImage )
 	}
 
 	return renderContainer

--- a/src/doc-service/inlineImage.js
+++ b/src/doc-service/inlineImage.js
@@ -1,16 +1,26 @@
 import { quoteattr } from './tags'
 
 export function InlineImage( imageLinker ) {
-	return function renderInlineImage( element ) {
-		const url = imageLinker( element );
+	return function renderInlineImage( image ) {
+		const url = imageLinker( image );
 		if ( !url ) {
 			return '';
 		}
 
-		const imgWidth = element.getWidth(),
-			imgHeight = element.getHeight(),
-			title = quoteattr( element.getAltTitle() ),
-			alt = quoteattr( element.getAltDescription() );
+		const imgWidth = image.getWidth(),
+		      imgHeight = image.getHeight();
+
+		let title = '',
+		    alt = '';
+
+		if ( image.getAltTitle ) {
+			title = quoteattr( image.getAltTitle() )
+		}
+
+		if ( image.getAltDescription ) {
+			alt = quoteattr( image.getAltDescription() )
+		}
+
 		return `<img src="${ url }" width="${ imgWidth }" height="${ imgHeight }" alt="${ alt }" title="${ title }">`
 	}
 }

--- a/src/image-upload-linker.js
+++ b/src/image-upload-linker.js
@@ -18,8 +18,8 @@ export function imageUploadLinker( uploadImage, imageCache ) {
 		if ( ! imageBlob.getName() ) {
 			const contentType = imageBlob.getContentType()
 			if ( contentTypeToExtension[ contentType ] ) {
-				Logger.log( 'Setting name to overpass.' + contentTypeToExtension[ contentType ] )
-				imageBlob.setName( 'overpass.' + contentTypeToExtension[ contentType ] );
+				Logger.log( 'Setting name to image.' + contentTypeToExtension[ contentType ] )
+				imageBlob.setName( 'image.' + contentTypeToExtension[ contentType ] );
 			} else {
 				Logger.log( 'No content type for ' + contentType );
 			}
@@ -33,6 +33,7 @@ export function imageUploadLinker( uploadImage, imageCache ) {
 			imageCache.set( image, url );
 			return url
 		} catch ( e ) {
+			DocumentApp.getUi().alert( JSON.stringify( e ) )
 			Logger.log( e )
 			return;
 		}

--- a/src/wp-client.js
+++ b/src/wp-client.js
@@ -112,18 +112,8 @@ export function WPClient( PropertiesService, UrlFetchApp ) {
 		const { blog_id, access_token } = site;
 		const path = `/sites/${ blog_id }/media/new`
 		const imageBlob = image.getBlob()
-		Logger.log( JSON.stringify( {
-			image: {
-				attributes: image.getAttributes(),
-				altDescription: image.getAltDescription(),
-				altTitle: image.getAltTitle()
-			},
-			imageBlob: {
-				contentType: imageBlob.getContentType(),
-				name: imageBlob.getName()
-			}
-		} ) )
-		if ( ! imageBlob.getName() ) {
+
+		if ( ! imageBlob.getName() && image.getAltDescription ) {
 			imageBlob.setName( image.getAltDescription() );
 		}
 		const boundary = '-----CUTHEREelH7faHNSXWNi72OTh08zH29D28Zhr3Rif3oupOaDrj'

--- a/test/doc-service.js
+++ b/test/doc-service.js
@@ -71,7 +71,7 @@ function mockText( text = MOCK_TEXT ) {
 }
 
 function containerOf( ...elements ) {
-	const container = td.object( ['getNumChildren', 'getChild', 'getType', 'getPreviousSibling', 'getNextSibling', 'getAttributes'] )
+	const container = td.object( ['getNumChildren', 'getChild', 'getType', 'getPreviousSibling', 'getNextSibling', 'getAttributes', 'getPositionedImages'] )
 
 	elements.forEach( ( el, i ) => {
 		td.when( container.getChild( i ) ).thenReturn( el )
@@ -79,6 +79,8 @@ function containerOf( ...elements ) {
 		td.when( el.getNextSibling() ).thenReturn( elements[i + 1] )
 	} )
 	td.when( container.getNumChildren() ).thenReturn( elements.length )
+	td.when( container.getPositionedImages() ).thenReturn( [] )
+
 	return container
 }
 
@@ -276,6 +278,20 @@ describe( 'renderContainer()', function() {
 			const actual = renderContainer( containerOf( image ) )
 
 			expect( actual ).to.equal( '<img src="https://cldup.com/E0CqGcUcow.gif" width="640" height="480" alt="Wapuu in a winter outfit" title="Wapuu">' )
+		} )
+	} )
+
+	describe( 'PositionedImage', function() {
+		it( 'should render in a paragraph', function() {
+			const p = paragraphOf( mockText( 'Who knew we owned 8000 salad plates' ) )
+			const positionedImage = td.object( [ 'getHeight', 'getWidth' ] );
+			td.when( positionedImage.getHeight() ).thenReturn( 716 );
+			td.when( positionedImage.getWidth() ).thenReturn( 717 );
+			td.when( p.getPositionedImages() ).thenReturn( [ positionedImage ] )
+			td.when( imageLinker( positionedImage ) ).thenReturn( 'https://cdn.wapuu.jp/wp-content/uploads/2015/12/wapuu_mcfly.png' )
+
+			const actual = renderContainer( p )
+			expect( actual ).to.equal( 'Who knew we owned 8000 salad plates<img src="https://cdn.wapuu.jp/wp-content/uploads/2015/12/wapuu_mcfly.png" width="717" height="716" alt="" title="">' )
 		} )
 	} )
 


### PR DESCRIPTION
This adds [PositionedImages](https://developers.google.com/apps-script/reference/document/positioned-image) to container elements, which should begin to address the problem of some images not being uploaded to WordPress. 

Right now it appends them to their parent element. A follow-up change is needed to position the images correctly. 

Closes #26