### PR TITLE
Add more error conditions

### DIFF
--- a/client/index.js
+++ b/client/index.js
@@ -96,10 +96,19 @@ function siteListItem( site ) {
  */
 function showError( msg, element, errorTitle ) {
 	var error = '<strong>Error ' + errorTitle + '</strong></p>';
+	var errorMatch = msg.message.match( /"message":"(.*?)"}/ );
 
 	// Bit of sniffing
 	if ( msg.message.indexOf( 'API calls to this blog have been disabled' ) !== -1 ) {
 		error += '<p>Jetpack JSON API has been disabled - please <a href="https://apps.wordpress.com/google-docs/support/#json-api" target="_blank">re-enable it</a> to continue posting.</p>';
+	} else if ( msg.message.indexOf( 'cURL error 28:' ) !== -1 ) {
+		error += '<p>Connection to your site timed out. Try again and/or investigate server load.</p>';
+	} else if ( msg.message.indexOf( '[-32700]' ) !== -1 ) {
+		error += '<p>Your site returned an unexpected response - are you <a href="https://apps.wordpress.com/google-docs/support/#other-plugins">running plugins</a> that may be causing a problem?</p>';
+	} else if ( msg.message.indexOf( 'HTTP status code was not 200' ) !== -1 ) {
+		error += '<p>Your server returned an unexpected response. This could be a misconfiguration, a bad plugin, or something may be broken. <a href="https://apps.wordpress.com/google-docs/support/#unexpected-response">Don\'t panic yet though!</a></p>';
+	} else if ( errorMatch && errorMatch.length > 0 ) {
+		error += '<p>' + errorMatch[ 1 ] + '</p>';
 	} else {
 		error += '<p><code style="font-size: 12px; word-wrap: break-word">' + msg.message + '</code></p>';
 		error += '<p><a href="https://support.wordpress.com" target="_blank">Please report this error</p>';

--- a/dist/javascript.html
+++ b/dist/javascript.html
@@ -142,10 +142,19 @@
 	 */
 	function showError( msg, element, errorTitle ) {
 		var error = '<strong>Error ' + errorTitle + '</strong></p>';
+		var errorMatch = msg.message.match( /"message":"(.*?)"}/ );
 
 		// Bit of sniffing
 		if ( msg.message.indexOf( 'API calls to this blog have been disabled' ) !== -1 ) {
 			error += '<p>Jetpack JSON API has been disabled - please <a href="https://apps.wordpress.com/google-docs/support/#json-api" target="_blank">re-enable it</a> to continue posting.</p>';
+		} else if ( msg.message.indexOf( 'cURL error 28:' ) !== -1 ) {
+			error += '<p>Connection to your site timed out. Try again and/or investigate server load.</p>';
+		} else if ( msg.message.indexOf( '[-32700]' ) !== -1 ) {
+			error += '<p>Your site returned an unexpected response - are you <a href="https://apps.wordpress.com/google-docs/support/#other-plugins">running plugins</a> that may be causing a problem?</p>';
+		} else if ( msg.message.indexOf( 'HTTP status code was not 200' ) !== -1 ) {
+			error += '<p>Your server returned an unexpected response. This could be a misconfiguration, a bad plugin, or something may be broken. <a href="https://apps.wordpress.com/google-docs/support/#unexpected-response">Don\'t panic yet though!</a></p>';
+		} else if ( errorMatch && errorMatch.length > 0 ) {
+			error += '<p>' + errorMatch[ 1 ] + '</p>';
 		} else {
 			error += '<p><code style="font-size: 12px; word-wrap: break-word">' + msg.message + '</code></p>';
 			error += '<p><a href="https://support.wordpress.com" target="_blank">Please report this error</p>';


### PR DESCRIPTION
This sniffs the error codes a bit more and tries to catch some of the more obvious ones.

Bad data in the Jetpack response:

<img width="304" alt="unexpected" src="https://cloud.githubusercontent.com/assets/1277682/23909670/4446ab90-08cf-11e7-89a8-e26ef9827dcc.png">


The 'HTTP status code was not 200' error:

<img width="316" alt="not-200" src="https://cloud.githubusercontent.com/assets/1277682/23909735/7a2259ee-08cf-11e7-8b89-79853d4e8197.png">

Slow server:
<img width="306" alt="time_out" src="https://cloud.githubusercontent.com/assets/1277682/23909767/8d82564c-08cf-11e7-8c64-9ccf8f33969f.png">

Lastly it tries to pull out the JSON error and just shows the message there:

<img width="308" alt="normal_error" src="https://cloud.githubusercontent.com/assets/1277682/23909674/4a05bd14-08cf-11e7-81f1-3eee7bd26806.png">

If it can't extract the JSON error it displays the whole string (no change here):

<img width="302" alt="normal_error" src="https://cloud.githubusercontent.com/assets/1277682/23898016/4ec9b968-08a7-11e7-9865-d7f67ed66f93.png">