### PR TITLE
Attach image uploads to the post

### DIFF
--- a/server/index.js
+++ b/server/index.js
@@ -133,30 +133,26 @@ export function postToWordPress( site_id ) {
 	const doc = DocumentApp.getActiveDocument();
 	const docProps = PropertiesService.getDocumentProperties();
 	const site = store.findSite( site_id );
-	const upload = image => wpClient.uploadImage( site, image );
-	const imageCache = ImageCache( site, docProps, md5 )
-	const imageUrlMapper = imageUploadLinker( upload, imageCache )
-	const renderContainer = DocService( DocumentApp, imageUrlMapper )
-	const body = renderContainer( doc.getBody() );
+
 	const cachedPostData = store.getPostStatus();
 	let postId, cachedPost;
 	if ( cachedPostData[ site_id ] ) {
 		cachedPost = cachedPostData[ site_id ]
 		postId = cachedPost.ID;
-	}
 
-	if ( cachedPost && postOnServerIsNewer( site, cachedPost ) ) {
-		const ui = DocumentApp.getUi();
-		const promptResponse = ui.alert(
-			'The post has been modified on the site',
-			'If you continue, any changes you made to the post on the site will be overwritten with this document.\n\nDo you want to overwrite the changes on the site?',
-			ui.ButtonSet.YES_NO
-		);
-
-		if ( promptResponse !== ui.Button.YES ) {
-			return {};
+		if ( postOnServerIsNewer( site, cachedPost ) && ! confirmOverwrite() ) {
+			return cachedPost;
 		}
+	} else {
+		const response = wpClient.postToWordPress( site, doc.getName(), '', 'new' );
+		postId = response.ID;
 	}
+
+	const upload = image => wpClient.uploadImage( site, image, postId );
+	const imageCache = ImageCache( site, docProps, md5 )
+	const imageUrlMapper = imageUploadLinker( upload, imageCache )
+	const renderContainer = DocService( DocumentApp, imageUrlMapper )
+	const body = renderContainer( doc.getBody() );
 
 	const response = wpClient.postToWordPress( site, doc.getName(), body, postId );
 
@@ -177,6 +173,17 @@ function postOnServerIsNewer( site, cachedPost ) {
 	const serverDate = getDateFromIso( serverPost.modified );
 
 	return ( localDate < serverDate );
+}
+
+function confirmOverwrite() {
+	const ui = DocumentApp.getUi();
+	const promptResponse = ui.alert(
+		'The post has been modified on the site',
+		'If you continue, any changes you made to the post on the site will be overwritten with this document. This will also unpublish the post if it has been published.\n\nDo you want to overwrite the changes on the site?',
+		ui.ButtonSet.YES_NO
+	);
+
+	return ( promptResponse !== ui.Button.YES )
 }
 
 export function listSites() {

--- a/server/index.js
+++ b/server/index.js
@@ -183,7 +183,7 @@ function confirmOverwrite() {
 		ui.ButtonSet.YES_NO
 	);
 
-	return ( promptResponse !== ui.Button.YES )
+	return ( promptResponse === ui.Button.YES )
 }
 
 export function listSites() {

--- a/server/wp-client.js
+++ b/server/wp-client.js
@@ -105,10 +105,12 @@ export function WPClient( PropertiesService, UrlFetchApp ) {
 	}
 
 	/**
+	 * @param {Site} site { blog_id, access_token }
 	 * @param {Blob} image a Google InlineImage
+	 * @param {Number} parentId blog post id to attach to
 	 * @return {object} response
 	 */
-	function uploadImage( site, image ) {
+	function uploadImage( site, image, parentId = 0 ) {
 		const { blog_id, access_token } = site;
 		const path = `/sites/${ blog_id }/media/new`
 		const imageBlob = image.getBlob()
@@ -121,7 +123,7 @@ export function WPClient( PropertiesService, UrlFetchApp ) {
 		const options = {
 			method: 'post',
 			contentType: `multipart/form-data; boundary=${ boundary }`,
-			payload: makeMultipartBody( { 'media[]': imageBlob }, boundary )
+			payload: makeMultipartBody( { 'media[0]': imageBlob, 'attrs[0][parent_id]': parentId }, boundary )
 		}
 
 		const response = post( access_token, path, options )


### PR DESCRIPTION
This changes the image uploads so that they are [attached](https://codex.wordpress.org/Using_Image_and_File_Attachments#Attachment_to_a_Post) to the blog post.

On a technical level, if it is a new post we create an empty draft post so that we have a post id to use in the image uploader.