### PR TITLE
Hide post types that support `exclude_from_external_editors`

### DIFF
--- a/client/post-type-input.jsx
+++ b/client/post-type-input.jsx
@@ -1,10 +1,16 @@
 export default ( { site, postType, onChoose } ) => {
 	// Do not show anything if the post has been created
 	if ( site.post ) {
-		return null;
+		return null
 	}
 
 	const postTypes = site.postTypes || []
+
+	if ( 1 === postTypes.length ) {
+		onChoose( postTypes[0].name )
+		return null
+	}
+
 	const postTypeObj = postTypes.find( ( t ) => t.name === postType )
 	const postTypeName = postTypeObj && postTypeObj.labels && postTypeObj.labels.singular_name
 

--- a/client/site.jsx
+++ b/client/site.jsx
@@ -10,13 +10,17 @@ export default class Site extends React.Component {
 		const { post } = props.site
 		const postTags = ( post && post.tags ) ? post.tags : []
 
+		const defaultPostType = ( props.site.postTypes && props.site.postTypes.length > 0 )
+			? props.site.postTypes[0].name
+			: 'post'
+
 		this.state = {
 			optionsExpanded: !! post,
 			siteRefreshing: false,
 			postCategories: ( post && post.categories ) ? post.categories : [],
 			postTags,
 			postTagsStr: postTags.join( ', ' ),
-			postType: ( post && post.type ) ? post.type : 'post'
+			postType: ( post && post.type ) ? post.type : defaultPostType
 		}
 		this.toggleOptions = this.toggleOptions.bind( this )
 		this.updateSite = this.updateSite.bind( this )

--- a/server/persistance.js
+++ b/server/persistance.js
@@ -60,7 +60,10 @@ export function Persistance( propertieService ) {
 		return {
 			name: postType.name,
 			labels: { singular_name: postType.labels.singular_name },
-			supports: { editor: postType.supports.editor },
+			supports: {
+				editor: postType.supports.editor,
+				exclude_from_external_editors: postType.supports.exclude_from_external_editors
+			},
 			taxonomies: postType.taxonomies
 		}
 	}
@@ -83,6 +86,7 @@ export function Persistance( propertieService ) {
 		const persistPostTypes = postTypes
 			.map( postTypeIdentity )
 			.filter( ( t ) => t.supports.editor )
+			.filter( ( t ) => ! t.supports.exclude_from_external_editors )
 
 		return {
 			access_token,


### PR DESCRIPTION
This allows Jetpack sites to hide specific post types from the list by adding `exclude_from_external_editors` to a post type's "supports" metadata